### PR TITLE
BGPolylineSplitter less gc

### DIFF
--- a/Assets/BansheeGz/BGCurve/Scripts/Cc/BGPolylineSplitter.cs
+++ b/Assets/BansheeGz/BGCurve/Scripts/Cc/BGPolylineSplitter.cs
@@ -490,9 +490,9 @@ namespace BansheeGz.BGSpline.Components
 
                 if ( !DistanceMaxConstrained )
                 {
-                    if ( result.Capacity < count - 1 )
+                    if ( result.Capacity < count )
                         result.Capacity = count;
-                    if ( points.Capacity < count - 1 )
+                    if ( points.Capacity < count )
                         points.Capacity = count;
                 }
                 

--- a/Assets/BansheeGz/BGCurve/Scripts/Cc/BGPolylineSplitter.cs
+++ b/Assets/BansheeGz/BGCurve/Scripts/Cc/BGPolylineSplitter.cs
@@ -488,6 +488,14 @@ namespace BansheeGz.BGSpline.Components
                 var sectionPoints = section.Points;
                 var count = sectionPoints.Count;
 
+                if ( !DistanceMaxConstrained )
+                {
+                    if ( result.Capacity < count - 1 )
+                        result.Capacity = count;
+                    if ( points.Capacity < count - 1 )
+                        points.Capacity = count;
+                }
+                
                 for (var j = 1; j < count; j++)
                 {
                     var point = sectionPoints[j];


### PR DESCRIPTION
Issue:
![image](https://user-images.githubusercontent.com/9093037/97834350-f6da9a80-1cd7-11eb-8f13-772ba94517ce.png)


Would it be able to precompute points count and set capacity at start in Build?