### PR TITLE
BGCcEditor as fallback default editor

### DIFF
--- a/Assets/BansheeGz/BGCurve/Scripts/Editor/CcInfra/BGCcEditor.cs
+++ b/Assets/BansheeGz/BGCurve/Scripts/Editor/CcInfra/BGCcEditor.cs
@@ -4,6 +4,7 @@ using BansheeGz.BGSpline.Curve;
 using UnityEditor;
 namespace BansheeGz.BGSpline.Editor
 {
+	[CustomEditor(typeof(BGCc), true)]
     public class BGCcEditor : UnityEditor.Editor
     {
         public event EventHandler ChangedParent;
@@ -159,6 +160,7 @@ namespace BansheeGz.BGSpline.Editor
 
         protected virtual void InternalOnInspectorGUI()
         {
+			DrawPropertiesExcluding(serializedObject, "m_Script", "showHandles", "hidden", "ccName", "parent");
         }
 
         protected virtual void InternalOnSceneGUI()


### PR DESCRIPTION
setting up the BGCcEditor to function as a fallback editor improves the BGCc creationg workflow by not requiring the implementation of an editor to maintain the BGCc workflow providing a more consistent experience.

This is handled by calling DrawPropertiesExcluding as a default implementation for InternalOnInspectorGUI
